### PR TITLE
fix: configure auto-sitemap with newest-first chronological ordering

### DIFF
--- a/build-blog.el
+++ b/build-blog.el
@@ -11,7 +11,8 @@
          :auto-preamble t
          :auto-sitemap t
          :sitemap-title "Blog Posts"
-         :sitemap-filename "sitemap.html"
+         :sitemap-filename "sitemap.org"
+         :sitemap-sort-files anti-chronologically
          :html-head "<style>
 body { font-family: Georgia, serif; max-width: 800px; margin: 40px auto; padding: 20px; line-height: 1.6; }
 h1, h2, h3 { color: #333; }


### PR DESCRIPTION
Fixes #2

Changes to `build-blog.el`:
- Keep `:auto-sitemap t` (we want this)
- Change `:sitemap-filename` from `sitemap.html` to `sitemap.org` so it gets properly published through org-publish
- Add `:sitemap-sort-files anti-chronologically` so newest posts appear first

Closes the old PR #8 which went the wrong direction (disabling sitemap).